### PR TITLE
Fix deprecated submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "succinct"]
 	path = succinct
-	url = git://github.com/ot/succinct.git
+	url = https://github.com/ot/succinct.git


### PR DESCRIPTION
GitHub has [deprecated](https://github.blog/2021-09-01-improving-git-protocol-security-github/) repo access using the `git://` protocol in 2021. The alternatives are either https (using `https://github.com/ot/succinct.git`) or ssh (using `git@github.com:ot/succinct.git`). The https variant is easier to use because one does not have to set up an ssh key.

If one tries to clone this repo (with submodules) without my change, git hangs for a very long time, and then fails.